### PR TITLE
Removed duplicate item

### DIFF
--- a/docs/dm_more/types.markdown
+++ b/docs/dm_more/types.markdown
@@ -117,7 +117,6 @@ DataMapper offers several choices for a data-store primitive.
 * Date
 * DateTime
 * BigDecimal
-* Float
 * Integer
 * Float
 * String


### PR DESCRIPTION
The item "Float" was listed twice in the list of primitives.
