### PR TITLE
Remove warning text about bug not allowing subclasses to define their own option values.

### DIFF
--- a/docs/properties.markdown
+++ b/docs/properties.markdown
@@ -136,13 +136,6 @@ DataMapper::Property.auto_validation(false)
 DataMapper::Property.writer(false)
 {% endhighlight %}
 
-Please note that this currently has the unfortunate side effect of not
-allowing subclasses to define their own option values. For example,
-setting the String length to 255 will affect the Text property even
-though it inherits from String and sets it's own default length to 65535.
-This is a [known bug](http://datamapper.lighthouseapp.com/projects/20609/tickets/1430)
-and will be fixed in the next release (1.0.3).
-
 You can of course still override these defaults by specifying any
 option explicitly when defining a specific property.
 


### PR DESCRIPTION
Remove warning text about bug not allowing subclasses to define their own option values. New versions of DataMapper no more have this bug.
