### PR TITLE
Mention the ':unique' trigger that generates the corresponding validator creation

### DIFF
--- a/docs/validations.markdown
+++ b/docs/validations.markdown
@@ -53,6 +53,9 @@ Triggers that generate validator creation:
   # implicitly creates a validates_present
   :required => true  # cannot be nil
 
+  # implicitly creates a validates_uniqueness
+  :unique => true # must be unique
+
   # implicitly creates a validates_length
   :length => 0..20  # must be between 0 and 20 characters in length
   :length => 1..20  # must be between 1 and 20 characters in length


### PR DESCRIPTION
In the auto validation code example, I found the ':unique' trigger missing. It's used in the "setting :messages  " code example and I've tried it in my application, it's working.
