### PR TITLE
Fixed minor grammar typo in index.html.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ title:        DataMapper
 ---
 
 <p class="blurb">
-DataMapper is a <a href="http://en.wikipedia.org/wiki/Object-relational_mapping">Object Relational Mapper</a>
+DataMapper is an <a href="http://en.wikipedia.org/wiki/Object-relational_mapping">Object Relational Mapper</a>
 written in <a href="http://www.ruby-lang.org/en/">Ruby</a>.
 The goal is to create an ORM which is fast, thread-safe and feature rich.
 </p>


### PR DESCRIPTION
Fixed minor grammar typo in index.html. 
Changed "a Object Relational Mapper" to "an Object Relational Mapper".
