### PR TITLE
Patch for rails app template - gsub .gitignore db/*.sqlite3 to db/*.db

### DIFF
--- a/templates/rails/application.rb
+++ b/templates/rails/application.rb
@@ -2,6 +2,7 @@
 
 apply 'http://datamapper.org/templates/rails/config.rb'
 apply 'http://datamapper.org/templates/rails/database.yml.rb'
+apply 'http://datamapper.org/templates/rails/gitignore.rb'
 
 inject_into_file  'app/controllers/application_controller.rb',
                   "require 'dm-rails/middleware/identity_map'\n",

--- a/templates/rails/gitignore.rb
+++ b/templates/rails/gitignore.rb
@@ -1,0 +1,1 @@
+gsub_file '.gitignore', /db\/\*\.sqlite3/, 'db/*.db'


### PR DESCRIPTION
As I created rails app from that DataMapper template, it changed my config/database.yml and changed extensions of sqlite3 databases from .sqlite3 to .db, so I've changed it also in .gitignore in this commit.
