### PR TITLE
jruby fixes + handling of rails version

### DIFF
--- a/templates/rails/database.yml.rb
+++ b/templates/rails/database.yml.rb
@@ -1,7 +1,7 @@
 # TODO think about a better way
 db_name = app_path.split('/').last
 
-database = options[:database]
+database = options[:database].sub(/jdbc/, '')
 database = 'postgres' if database == 'postgresql'
 database = 'sqlite'   if database == 'sqlite3'
 

--- a/templates/rails/gemfile.rb
+++ b/templates/rails/gemfile.rb
@@ -3,7 +3,7 @@
 DATAMAPPER = '#{DATAMAPPER}'
 RSPEC      = '#{RSPEC}'
 
-database = options[:database]
+database = options[:database].sub(/jdbc/, '')
 database = 'postgres' if database == 'postgresql'
 database = 'sqlite'   if database == 'sqlite3'
 
@@ -12,7 +12,7 @@ create_file 'Gemfile' do
 <<-GEMFILE
 source 'http://rubygems.org'
 
-RAILS_VERSION = '~> 3.1.1'
+RAILS_VERSION = '#{Rails::VERSION::STRING}'
 DM_VERSION    = '~> 1.2.0'
 
 gem 'activesupport',      RAILS_VERSION, :require => 'active_support'


### PR DESCRIPTION
- allow to use this template with jruby with newer rails versions as well - from rails-3.0.10 onwards rails generates jruby specific Gemfile and database names when used with jruby
- since 'bundle install' runs at the end of the rails template then it install the rails version with which the application got generated. when I create a rails app with version 3.1.1 it should bundle that very same version.
