### PR TITLE
Rails templates that more closely mirror a standard non-DM Rails app.

### DIFF
--- a/templates/rails/application.rb
+++ b/templates/rails/application.rb
@@ -29,14 +29,6 @@ CODE
 
 say ''
 say '---------------------------------------------------------------------------'
-say "Edit your Gemfile (do not forget to run 'bundle install' after doing that)"
-say '---------------------------------------------------------------------------'
-say 'If you want to use rspec for testing, you first need to uncomment the line'
-say "that declares it in the Gemfile. The you need to run 'bundle install' again"
-say "Once that's done, you need to actually install it into your app and update"
-say "your spec_helper as shown in the dm-rails README"
-say '---------------------------------------------------------------------------'
-say 'Install rspec (optional):             script/rails g rspec:install'
 say 'Have a look at the dm-rails README:   http://github.com/datamapper/dm-rails'
 say '---------------------------------------------------------------------------'
 say 'Have a look at available rake tasks:  rake -T'
@@ -44,6 +36,6 @@ say 'Generate a simple scaffold:           rails g scaffold Person name:string'
 say 'Create, automigrate and seed the DB:  rake db:setup'
 say 'Start the server:                     script/rails server'
 say '---------------------------------------------------------------------------'
-say 'After the sever booted, point your browser at http://localhost:3000/people'
+say 'After the server booted, point your browser at http://localhost:3000/people'
 say '---------------------------------------------------------------------------'
 say ''

--- a/templates/rails/config.rb
+++ b/templates/rails/config.rb
@@ -1,19 +1,13 @@
 gsub_file 'config/application.rb', /require 'rails\/all'/ do
 <<-RUBY
-# Pick the frameworks you want:
+# Comment out the frameworks you don't want (if you don't want ActionMailer,
+# make sure to comment out the `config.action_mailer` lines in your
+# config/environments/development.rb and config/environments/test.rb files):
 require 'action_controller/railtie'
 require 'dm-rails/railtie'
 require 'sprockets/railtie'
-# require 'action_mailer/railtie'
-# require 'active_resource/railtie'
-# require 'rails/test_unit/railtie'
+require 'action_mailer/railtie'
+require 'active_resource/railtie'
+require 'rails/test_unit/railtie'
 RUBY
-end
-
-gsub_file 'config/environments/development.rb', /config.action_mailer.raise_delivery_errors = false/ do
-  "# config.action_mailer.raise_delivery_errors = false"
-end
-
-gsub_file 'config/environments/test.rb', /config.action_mailer.delivery_method = :test/ do
-  "# config.action_mailer.delivery_method = :test"
 end

--- a/templates/rails/gemfile.rb
+++ b/templates/rails/gemfile.rb
@@ -18,6 +18,7 @@ DM_VERSION    = '~> 1.2.0'
 gem 'activesupport',      RAILS_VERSION, :require => 'active_support'
 gem 'actionpack',         RAILS_VERSION, :require => 'action_pack'
 gem 'actionmailer',       RAILS_VERSION, :require => 'action_mailer'
+gem 'activeresource',     RAILS_VERSION, :require => 'active_resource'
 gem 'railties',           RAILS_VERSION, :require => 'rails'
 gem 'tzinfo'
 
@@ -48,6 +49,7 @@ gem 'dm-aggregates',        DM_VERSION
 gem 'dm-timestamps',        DM_VERSION
 gem 'dm-observer',          DM_VERSION
 
+
 # Gems used only for assets and not required
 # in production environments by default.
 group :assets do
@@ -56,26 +58,23 @@ group :assets do
   gem 'uglifier', '>= 1.0.3'
 end
 
-group(:development, :test) do
+gem 'jquery-rails'
 
-  # Uncomment this if you want to use rspec for testing your application
+# To use ActiveModel has_secure_password
+# gem 'bcrypt-ruby', '~> 3.0.0'
 
-  # gem 'rspec-rails', '~> 2.0.1'
+# Use unicorn as the web server
+# gem 'unicorn'
 
-  # To get a detailed overview about what queries get issued and how long they take
-  # have a look at rails_metrics. Once you bundled it, you can run
-  #
-  #   rails g rails_metrics Metric
-  #   rake db:automigrate
-  #
-  # to generate a model that stores the metrics. You can access them by visiting
-  #
-  #   /rails_metrics
-  #
-  # in your rails application.
+# Deploy with Capistrano
+# gem 'capistrano'
 
-  # gem 'rails_metrics', '~> 0.1', :git => 'git://github.com/engineyard/rails_metrics'
+# To use debugger
+# gem 'ruby-debug19', :require => 'ruby-debug'
 
+group :test do
+  # Pretty printed test output
+  gem 'turn', '~> 0.8.3', :require => false
 end
 
 GEMFILE


### PR DESCRIPTION
This addresses Issue #28. Currently, while the rails templates do specify Rails 3.1, they remove support for Assets/Sprockets, resulting in a broken app (stylesheets/javascript fail to function properly).

I've also updated this to act more like a default Rails 3.1 application. I think it's misleading to the user, especially if they're new to rails, to turn off support for some Rails components (ActionMailer, ActiveResource), Testing (encouraging RSpec over TestUnit), and JS (jquery-rails) by default; it's my belief that the only thing these templates should do is swap out DataMapper for ActiveRecord, and leave everything else identical to a vanilla Rails 3.1 application. And this exclusion is not consistent; for example, the `require 'action_mailer/railtie'` and `require 'active_resource/railtie'` lines are both commented out, but only the `actionmailer` gem is included in the `Gemfile`.

This might be a bigger philosophy discussion on what to include/not include by default... maybe having two sets of templates, one "opinionated" template with stripped down Rails components, RSpec instead of TestUnit, etc., and then one nearly identical to Rails' default settings? If everyone feels that would be better, I can update the pull request with two sets of templates.
