### PR TITLE
obey the rails version

### DIFF
--- a/templates/rails/gemfile.rb
+++ b/templates/rails/gemfile.rb
@@ -12,7 +12,7 @@ create_file 'Gemfile' do
 <<-GEMFILE
 source 'http://rubygems.org'
 
-RAILS_VERSION = '~> 3.1.3'
+RAILS_VERSION = '#{Rails::VERSION::STRING}'
 DM_VERSION    = '~> 1.2.0'
 
 gem 'activesupport',      RAILS_VERSION, :require => 'active_support'


### PR DESCRIPTION
if I generate a rails application for version 3.x.y I do expect the rails version to be 3.x.y. especially when I am using something like `rails _3.0.1_ new myapp`
