### PR TITLE
Change single quote to double quote.

### DIFF
--- a/docs/validations.md
+++ b/docs/validations.md
@@ -143,8 +143,8 @@ in the property options.
   property :email, String, :required => true, :unique => true,
     :format   => :email_address,
     :messages => {
-      :presence  => 'We need your email address.',
-      :is_unique => 'We already have that email.',
+      :presence  => "We need your email address.",
+      :is_unique => "We already have that email.",
       :format    => "Doesn't look like an email address to me ..."
     }
 {% endhighlight %}


### PR DESCRIPTION
Just a way to make the example valid Ruby code and better-looking on the website.
