### PR TITLE
Document String and Text propertly default length limits

### DIFF
--- a/docs/properties.md
+++ b/docs/properties.md
@@ -188,8 +188,8 @@ Available Types
 DM-Core supports the following 'primitive' data-types.
 
 * Boolean
-* String
-* Text
+* String (default length limit of 50 characters)
+* Text (defaults to lazy loading and length limit of 65535 characters)
 * Float
 * Integer
 * Decimal


### PR DESCRIPTION
Hi. I just spent too long trying to figure out why a new String property I added was failing validation. The data I was trying to insert was only 64 characters, which is far too short to trigger any kind of gut reaction that the length could be a problem. The documentation didn't give any indication there is a built-in hardcoded default limit. The validation failure message didn't indicate what was causing the failure.

Anyway, once I dug into the source I quickly found the default length limit culprit. I documented it here in hopes of saving someone else the same pain.

Personally I'd prefer to see no length limit by default; if I wanted a length validation I would've added one to the model or used the earlier example DataMapper::Property::String.length(255) etc. Any default is going to be arbitrary, and the Text limit seems just as likely to trip someone up who's not expecting any limit at all. That's my $0.02 on it, but at the very least I wanted to get the limits documented.

Thanks,
Jon
