### PR TITLE
fix gitub wiki link

### DIFF
--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -5,6 +5,6 @@
           <li><a href="/docs/">Documentation</a></li>
           <li><a href="/development/">Development</a></li>
           <li><a href="/contribute.html">Contribute</a></li>
-          <li><a href="http://wiki.github.com/datamapper/dm-core">Wiki</a></li>
+          <li><a href="https://github.com/datamapper/dm-core/wiki">Wiki</a></li>
           <li><a href="/getting-started.html" id="getStarted">Get Started</a></li>
         </ul>


### PR DESCRIPTION
saves a browser redirect and is future-proof if github decides to dump the legacy redirects some day
