### PR TITLE
Corrected supplementary properties

### DIFF
--- a/docs/associations.md
+++ b/docs/associations.md
@@ -126,8 +126,8 @@ class Tagging
 
   property :id, Serial
   
-  property :tag_id,          :unique_index => :uniqueness
-  property :tagged_photo_id, :unique_index => :uniqueness
+  property :tag_id,          :unique_index => :uniqueness, :required => true
+  property :tagged_photo_id, :unique_index => :uniqueness, :required => true
 
   belongs_to :tag
   belongs_to :tagged_photo, 'Photo'


### PR DESCRIPTION
When a supplementary property is added for an association, the default changes from required to not required. To generate the same database schema as before, :required => true needs to be added to the property.
