### PR TITLE
Remove deprecated jekyll configuration settings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,3 @@
-auto:        true
-server:      true
 markdown:    rdiscount
-pygments:    true
+highlighter: pygments
 permalink:   none


### PR DESCRIPTION
Was getting the following errors when testing locally on jekyll 3.4.4 (current version being 3.5.0)

> Configuration file: /home/datamapper/_config.yml
>  Deprecation: Auto-regeneration can no longer be set from your configuration file(s). Use the --[no-]watch/-w command-line option instead.
>        Deprecation: The 'server' configuration option is no longer accepted. Use the 'jekyll serve' subcommand to serve your site with WEBrick.
>        Deprecation: The 'pygments' configuration option has been renamed to 'highlighter'. Please update your config file accordingly. The allowed values are 'rouge', 'pygments' or null.
